### PR TITLE
add kind for NIP-99

### DIFF
--- a/src/Nostr.Client/Messages/NostrKind.cs
+++ b/src/Nostr.Client/Messages/NostrKind.cs
@@ -56,6 +56,8 @@
 
         LiveEvent = 30311,
 
+        ClassifiedListing = 30402,
+
         // nip-16 regular events                   [ 1000- 9999]
         // nip-16 replaceable events               [10000-19999]
         // nip-16 ephemeral  events                [20000-29999]


### PR DESCRIPTION
Fixes #6 by adding `kind:30402` for the Publisher tab.

That seems to be all that's necessary to support https://github.com/nostr-protocol/nips/blob/master/99.md